### PR TITLE
Update JS code to ES6 modules

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -14,4 +14,10 @@ Images	(http://unsplash.com - CC0 licensed)
 Icons	Font Awesome (http://fortawesome.github.com/Font-Awesome/)
 Other	html5shiv.js (@afarkas @jdalton @jon_neal @rem)
 
-Note: All the images used in this template is for demo use only, we are not responsible for any copyrights issue.	
+Note: All the images used in this template is for demo use only, we are not responsible for any copyrights issue.
+
+Updates
+=======
+The custom scripts have been modernised to ES6 syntax and now use module loading
+via `<script type="module">`. Ajax calls now rely on the Fetch API for better
+browser support.

--- a/js/music.js
+++ b/js/music.js
@@ -1,7 +1,6 @@
-$(function () {
-        var $col;
-            $("#nav").css("background-color",col=setbackground());
-            //$("#home").css("background-color",col);
-            $(".sm2-main-controls").css("background-color", col);
-            $(".sm2-playlist-drawer").css("background-color", $(".sm2-main-controls").css("background-color"));
+$(() => {
+    const col = setbackground();
+    $("#nav").css("background-color", col);
+    $(".sm2-main-controls").css("background-color", col);
+    $(".sm2-playlist-drawer").css("background-color", $(".sm2-main-controls").css("background-color"));
 });

--- a/js/myfunctions.js
+++ b/js/myfunctions.js
@@ -1,96 +1,67 @@
 /**
  * Created by thaonzo on 24/09/2015.
  */
-var $srctype;
-$srctype="electro/";
-function setbackground()
-{
-    window.setTimeout( "setbackground()", 2000000); // 5000 milliseconds delay
+const srctype = "electro/";
 
-    var colors = [
-        "#1abc9c", //peach
-        "#1abc9c", //violet
-        "#2980b9", //lt blue
-        "#34495e", //cyan
-        "#e67e22", //tan
-        "#c0392b", //lt green
-        "#9b59b6", //lt yellow
-        "#f1c40f", //lt orange
-        "#95a5a6", //lt grey
-        "#D91E18", //Thunderbird
-        "#663399", //REBECCAPURPLE
-        "#446CB3", //SAN MARINO
-        "#52B3D9", //SHAKESPEARE
-        "#C5EFF7", //HUMMING BIRD
-        "#03A678", //FREE SPEECH AQUAMARINE
-        "#F4B350" //CASABLANCA
+const setbackground = () => {
+    setTimeout(setbackground, 2000000);
+    const colors = [
+        "#1abc9c", // peach
+        "#1abc9c", // violet
+        "#2980b9", // lt blue
+        "#34495e", // cyan
+        "#e67e22", // tan
+        "#c0392b", // lt green
+        "#9b59b6", // lt yellow
+        "#f1c40f", // lt orange
+        "#95a5a6", // lt grey
+        "#D91E18", // Thunderbird
+        "#663399", // REBECCAPURPLE
+        "#446CB3", // SAN MARINO
+        "#52B3D9", // SHAKESPEARE
+        "#C5EFF7", // HUMMING BIRD
+        "#03A678", // FREE SPEECH AQUAMARINE
+        "#F4B350" // CASABLANCA
     ];
-
     return colors[Math.floor(Math.random() * colors.length)];
+};
 
-}
-
-function newsong(sData) {
-
-    var MusicUrl;
-    MusicUrl = 'music/'+$srctype+'mp3/'+sData.replace(/ /g,'%20')+'.mp3';
-    var newhtml = $(".oio").html();
-    if(newhtml.search(MusicUrl)>-1){
+const newsong = (sData) => {
+    const MusicUrl = `music/${srctype}mp3/${sData.replace(/ /g, '%20')}.mp3`;
+    let newhtml = $(".oio").html();
+    if (newhtml.search(MusicUrl) > -1) {
         request(newsong);
-    }
-    else {
-        newhtml += ' <li><a href="' + MusicUrl + '">' + sData + '</a></li>';
-        $(".oio").html(newhtml);
-        //$(".download").attr('href','music/'+$srctype+'mp3/'+sData+'.mp3');
-
-
-    }
-}
-function getXMLHttpRequest() {
-    var xhr = null;
-
-    if (window.XMLHttpRequest || window.ActiveXObject) {
-        if (window.ActiveXObject) {
-            try {
-                xhr = new ActiveXObject("Msxml2.XMLHTTP");
-            } catch(e) {
-                xhr = new ActiveXObject("Microsoft.XMLHTTP");
-            }
-        } else {
-            xhr = new XMLHttpRequest();
-        }
     } else {
-        alert("Votre navigateur ne supporte pas l'objet XMLHTTPRequest...");
-        return null;
+        newhtml += ` <li><a href="${MusicUrl}">${sData}</a></li>`;
+        $(".oio").html(newhtml);
+        // $(".download").attr('href', `music/${srctype}mp3/${sData}.mp3`);
     }
+};
 
-    return xhr;
-}
-function request(callback) {
-    var xhr = getXMLHttpRequest();
+const request = (callback) => {
+    fetch("control/setmusi.php", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/x-www-form-urlencoded"
+        },
+        body: `variable1=${srctype}`
+    })
+        .then((response) => response.text())
+        .then(callback)
+        .catch((err) => console.error(err));
+};
 
-    xhr.onreadystatechange = function() {
-        if (xhr.readyState == 4 && (xhr.status == 200 || xhr.status == 0)) {
-            callback(xhr.responseText);
-        }
-    };
-    xhr.open("POST", "control/setmusi.php", true);
-    xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
-    xhr.send("variable1="+$srctype+"");
-}
-
-$(document).ready(function() {
+$(document).ready(() => {
     $('.navbar-nav [data-toggle="tooltip"]').tooltip();
-    $('.navbar-twitch-toggle').on('click', function(event) {
+    $('.navbar-twitch-toggle').on('click', (event) => {
         event.preventDefault();
         $('.navbar-twitch').toggleClass('open');
     });
 
-    $('.nav-style-toggle').on('click', function(event) {
+    $('.nav-style-toggle').on('click', (event) => {
         event.preventDefault();
-        var $current = $('.nav-style-toggle.disabled');
-
-        $('.navbar-twitch').removeClass('navbar-'+$current.data('type'));
-        $('.navbar-twitch').addClass('navbar-'+$(this).data('type'));
+        const $current = $('.nav-style-toggle.disabled');
+        $('.navbar-twitch').removeClass(`navbar-${$current.data('type')}`);
+        $('.navbar-twitch').addClass(`navbar-${$(event.currentTarget).data('type')}`);
     });
 });

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "randommusic",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module"
+}

--- a/view/script.php
+++ b/view/script.php
@@ -26,7 +26,7 @@ soundManager.setup({
   }
 });
 </script>
-<script src="js/myfunctions.js"></script>
-<script src="js/music.js"></script>
+<script type="module" src="js/myfunctions.js"></script>
+<script type="module" src="js/music.js"></script>
 <script src="js/bar-ui.js"></script>
 


### PR DESCRIPTION
## Summary
- modernise JS to use ES6 syntax
- use `fetch` instead of `XMLHttpRequest`
- convert initialization script to an ES module
- note modernisation in README
- init a basic `package.json` and enable ES module type

## Testing
- `php -l index.php`
- `php -l main.php`
- `php -l view/script.php`
- `php -l view/head.php`
- `php -l view/player.php`
- `php -l view/navigation.php`
- `php -l view/home.php`
- `php -l control/setmusi.php`


------
https://chatgpt.com/codex/tasks/task_e_68762a66d924832fb07bee442be70917