### PR TITLE
Integrate Jamendo API and add source info tooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Ce dépôt contient un petit site web permettant d'écouter de la musique gratui
 - Les fichiers musicaux sont rangés par genre dans le répertoire `music/`. Chaque genre possède un sous-dossier `mp3/` contenant des pistes au format MP3.
 - La playlist est générée côté client à partir du fichier `js/playlist.js` qui référence l'ensemble des morceaux disponibles.
 - Les fichiers CSS et JavaScript nécessaires au thème se trouvent respectivement dans `css/` et `js/`.
+- Un appel à l'API [Jamendo](https://api.jamendo.com/) permet de compléter dynamiquement la liste avec des titres libres de droits.
 
 ## Lancer le site en local
 

--- a/css/lofi.css
+++ b/css/lofi.css
@@ -35,3 +35,16 @@ h1 {
   margin: 0 1rem;
   position: static;
 }
+
+.info-btn {
+  background: none;
+  border: 1px solid #fff;
+  border-radius: 50%;
+  width: 1.5rem;
+  height: 1.5rem;
+  line-height: 1.5rem;
+  text-align: center;
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.9rem;
+}

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="css/lofi.css">
 </head>
 <body>
-<h1>Random Music</h1>
+<h1>Random Music <button id="api-info" class="info-btn" title="Local library">i</button></h1>
 <div class="player-container">
   <div class="glass">
     <div class="sm2-bar-ui full-width">

--- a/js/player.js
+++ b/js/player.js
@@ -1,15 +1,40 @@
 $(function(){
-  const items = [];
-  for(const [genre,songs] of Object.entries(playlist)){
-    songs.forEach(name=>items.push({genre,name}));
-  }
-  function shuffle(array){
-    for(let i=array.length-1;i>0;i--){const j=Math.floor(Math.random()*(i+1));[array[i],array[j]]=[array[j],array[i]];}
-  }
-  shuffle(items);
   const list = $('.sm2-playlist-bd');
-  items.forEach(t => {
-    const path = `music/${t.genre}/mp3/${encodeURIComponent(t.name)}.mp3`;
-    list.append(`<li><a href="${path}">${t.name}</a></li>`);
-  });
+  const items = [];
+
+  function shuffle(array){
+    for(let i=array.length-1;i>0;i--){
+      const j=Math.floor(Math.random()*(i+1));
+      [array[i],array[j]]=[array[j],array[i]];
+    }
+  }
+
+  function render(){
+    list.empty();
+    shuffle(items);
+    items.forEach(t => list.append(`<li><a href="${t.url}">${t.name}</a></li>`));
+  }
+
+  for(const [genre,songs] of Object.entries(playlist)){
+    songs.forEach(name=>{
+      const url = `music/${genre}/mp3/${encodeURIComponent(name)}.mp3`;
+      items.push({name,url});
+    });
+  }
+
+  render();
+
+  const JAMENDO_CLIENT_ID = 'YOUR_CLIENT_ID';
+  const apiUrl = `https://api.jamendo.com/v3.0/tracks/?client_id=${JAMENDO_CLIENT_ID}&format=json&limit=10&audioformat=mp31`;
+
+  fetch(apiUrl)
+    .then(r=>r.json())
+    .then(data=>{
+      data.results.forEach(track=>{
+        items.push({name:track.name,url:track.audio});
+      });
+      render();
+      $('#api-info').attr('title','Music from local library and Jamendo API');
+    })
+    .catch(err=>console.error('Jamendo API error',err));
 });


### PR DESCRIPTION
## Summary
- integrate Jamendo API to enrich playlist with royalty-free tracks
- add small info button and styling to show music source
- document external API usage in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6895a5424388832fa2e5e325eff26ca9